### PR TITLE
Support any developer style language

### DIFF
--- a/weblate/machinery/base.py
+++ b/weblate/machinery/base.py
@@ -155,8 +155,8 @@ class MachineTranslation:
 
     def map_language_code(self, code):
         """Map language code to service specific."""
-        if code == "en_devel":
-            code = "en"
+        if code.endswith("_devel"):
+            code = code[:-6]
         if code in self.language_map:
             return self.language_map[code]
         return code


### PR DESCRIPTION
Instead of supporting only en_devel, we are now allow user to create any other *_devel

## Proposed changes

The developer style source language happens in any source language but not only english. So we should allow other style, such as id_devel or vi_devel, so that the machine translation can work properly.

Without this change, the Microsoft Terminology API does not work with *_devel (excepts en_devel) because of wrong language code.

## Other information

This change is very small